### PR TITLE
Remove preconditions for numerical overflow

### DIFF
--- a/Sources/JulianDayNumber/HebrewCalendar.swift
+++ b/Sources/JulianDayNumber/HebrewCalendar.swift
@@ -221,14 +221,11 @@ public struct HebrewCalendar: Calendar {
 extension HebrewCalendar {
 	/// Returns the Julian day number of the first day of Tishrei in the specified year.
 	///
-	/// - attention: No validation check is performed on the year value.
-	///
 	/// - parameter Y: A year A.M.
 	///
 	/// - returns: The Julian day number of the first day of Tishrei in the specified year.
 	static func firstDayOfTishrei(year Y: Year) -> JulianDayNumber {
 		precondition(Y > 0, "First day of Tishrei calculations only valid for year numbers > 0")
-		precondition(Y < 974245219737, "Year values above 974245219736 cause numerical overflow using 64-bit integers")
 
 		// It is possible to adjust the year by a multiple of the cycle to have this function
 		// calculate correct values for the first day of Tishrei in proleptic years. However,
@@ -253,7 +250,6 @@ extension HebrewCalendar {
 	/// - returns: The year containing the specified Julian day number.
 	static func yearContaining(julianDayNumber J: JulianDayNumber) -> Year {
 		precondition(J >= epoch, "Julian day number must be >= epoch")
-		precondition(J < 355839970905665, "Julian day numbers above 355839970905664 cause numerical overflow using 64-bit integers")
 
 		let M = (25920 * (J - 347996)) / 765433 + 1
 		var Y = 19 * (M / 235) + (19 * (M % 235) - 2) / 235 + 1

--- a/Sources/JulianDayNumber/JDNConverter.swift
+++ b/Sources/JulianDayNumber/JDNConverter.swift
@@ -70,11 +70,8 @@ struct JDNConverter {
 		// Richards' algorithm is only valid for positive JDNs.
 		if J < 0 {
 			ΔcalendarCycles = -(J / p) + 1
-			precondition(ΔcalendarCycles <= .max / p, "Julian day number too small")
 			J += ΔcalendarCycles * p
 		}
-
-		precondition(J <= (.max - v) / r - j, "Julian day number too large")
 
 		let f = J + j
 		let e = r * f + v

--- a/Sources/JulianDayNumber/JDNGregorianConverter.swift
+++ b/Sources/JulianDayNumber/JDNGregorianConverter.swift
@@ -80,11 +80,8 @@ struct JDNGregorianConverter {
 		// Richards' algorithm is only valid for positive JDNs.
 		if J < 0 {
 			ΔcalendarCycles = -(J / gregorianIntercalatingCycle.days) + 1
-			precondition(ΔcalendarCycles <= .max / gregorianIntercalatingCycle.days, "Julian day number too small")
 			J += ΔcalendarCycles * gregorianIntercalatingCycle.days
 		}
-
-		precondition(J <= .max - j, "Julian day number too large")
 
 		var f = J + j
 		f = f + (((4 * J + B) / 146097) * 3) / 4 + C

--- a/Sources/JulianDayNumber/JDNSakaConverter.swift
+++ b/Sources/JulianDayNumber/JDNSakaConverter.swift
@@ -76,11 +76,8 @@ struct JDNSakaConverter {
 		// Richards' algorithm is only valid for positive JDNs.
 		if J < 0 {
 			ΔcalendarCycles = -(J / gregorianIntercalatingCycle.days) + 1
-			precondition(ΔcalendarCycles <= .max / gregorianIntercalatingCycle.days, "Julian day number too small")
 			J += ΔcalendarCycles * gregorianIntercalatingCycle.days
 		}
-
-		precondition(J <= .max - j, "Julian day number too large")
 
 		var f = J + j
 		f = f + (((4 * J + B) / 146097) * 3) / 4 + C


### PR DESCRIPTION
There is no good way for the caller to know if a precondition will trigger so just leave it to Swift.