### PR TITLE
Disable tests with 64-bit int literals on 32-bit platforms

### DIFF
--- a/Tests/JulianDayNumberTests/BahaiCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/BahaiCalendarTests.swift
@@ -91,10 +91,12 @@ import Testing
 		var jdn = BahaiCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForBahaiCalendar == jdn)
 
+#if !(arch(i386) || arch(arm) || arch(arm64_32))
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForBahaiCalendar: JulianDayNumber = 2305795661307959248
 		(Y, M, D) = BahaiCalendar.dateFromJulianDayNumber(largestJDNForBahaiCalendar)
 		jdn = BahaiCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(largestJDNForBahaiCalendar == jdn)
+#endif
 	}
 }

--- a/Tests/JulianDayNumberTests/BahaiCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/BahaiCalendarTests.swift
@@ -91,7 +91,7 @@ import Testing
 		var jdn = BahaiCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForBahaiCalendar == jdn)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForBahaiCalendar: JulianDayNumber = 2305795661307959248
 		(Y, M, D) = BahaiCalendar.dateFromJulianDayNumber(largestJDNForBahaiCalendar)

--- a/Tests/JulianDayNumberTests/FrenchRepublicanCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/FrenchRepublicanCalendarTests.swift
@@ -91,10 +91,12 @@ import Testing
 		var jdn = FrenchRepublicanCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForFrenchRepublicanCalendar == jdn)
 
+#if !(arch(i386) || arch(arm) || arch(arm64_32))
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForFrenchRepublicanCalendar: JulianDayNumber = 2305795661307960548
 		(Y, M, D) = FrenchRepublicanCalendar.dateFromJulianDayNumber(largestJDNForFrenchRepublicanCalendar)
 		jdn = FrenchRepublicanCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(largestJDNForFrenchRepublicanCalendar == jdn)
+#endif
 	}
 }

--- a/Tests/JulianDayNumberTests/FrenchRepublicanCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/FrenchRepublicanCalendarTests.swift
@@ -91,7 +91,7 @@ import Testing
 		var jdn = FrenchRepublicanCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForFrenchRepublicanCalendar == jdn)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForFrenchRepublicanCalendar: JulianDayNumber = 2305795661307960548
 		(Y, M, D) = FrenchRepublicanCalendar.dateFromJulianDayNumber(largestJDNForFrenchRepublicanCalendar)

--- a/Tests/JulianDayNumberTests/GregorianCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/GregorianCalendarTests.swift
@@ -135,7 +135,7 @@ import Testing
 		var jdn = GregorianCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForGregorianCalendar == jdn)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForGregorianCalendar: JulianDayNumber = 2305795661307959247
 		(Y, M, D) = GregorianCalendar.dateFromJulianDayNumber(largestJDNForGregorianCalendar)

--- a/Tests/JulianDayNumberTests/GregorianCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/GregorianCalendarTests.swift
@@ -135,10 +135,12 @@ import Testing
 		var jdn = GregorianCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForGregorianCalendar == jdn)
 
+#if !(arch(i386) || arch(arm) || arch(arm64_32))
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForGregorianCalendar: JulianDayNumber = 2305795661307959247
 		(Y, M, D) = GregorianCalendar.dateFromJulianDayNumber(largestJDNForGregorianCalendar)
 		jdn = GregorianCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(largestJDNForGregorianCalendar == jdn)
+#endif
 	}
 }

--- a/Tests/JulianDayNumberTests/HebrewCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/HebrewCalendarTests.swift
@@ -253,7 +253,7 @@ import Testing
 		var jdn = HebrewCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForHebrewCalendar == jdn)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 #if true
 		let largestJDNForHebrewCalendar: JulianDayNumber = 355839970905570

--- a/Tests/JulianDayNumberTests/HebrewCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/HebrewCalendarTests.swift
@@ -253,6 +253,7 @@ import Testing
 		var jdn = HebrewCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForHebrewCalendar == jdn)
 
+#if !(arch(i386) || arch(arm) || arch(arm64_32))
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 #if true
 		let largestJDNForHebrewCalendar: JulianDayNumber = 355839970905570
@@ -262,5 +263,6 @@ import Testing
 		(Y, M, D) = HebrewCalendar.dateFromJulianDayNumber(largestJDNForHebrewCalendar)
 		jdn = HebrewCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(largestJDNForHebrewCalendar == jdn)
+#endif
 	}
 }

--- a/Tests/JulianDayNumberTests/SakaCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/SakaCalendarTests.swift
@@ -92,7 +92,7 @@ import Testing
 		var jdn = SakaCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForSakaCalendar == jdn)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForSakaCalendar: JulianDayNumber = 2305795661307959298
 		(Y, M, D) = SakaCalendar.dateFromJulianDayNumber(largestJDNForSakaCalendar)

--- a/Tests/JulianDayNumberTests/SakaCalendarTests.swift
+++ b/Tests/JulianDayNumberTests/SakaCalendarTests.swift
@@ -92,10 +92,12 @@ import Testing
 		var jdn = SakaCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(smallestJDNForSakaCalendar == jdn)
 
+#if !(arch(i386) || arch(arm) || arch(arm64_32))
 		// Values larger than this cause an arithmetic overflow in dateFromJulianDayNumber
 		let largestJDNForSakaCalendar: JulianDayNumber = 2305795661307959298
 		(Y, M, D) = SakaCalendar.dateFromJulianDayNumber(largestJDNForSakaCalendar)
 		jdn = SakaCalendar.julianDayNumberFrom(year: Y, month: M, day: D)
 		#expect(largestJDNForSakaCalendar == jdn)
+#endif
 	}
 }


### PR DESCRIPTION
This will be unnecessary if `JulianDayNumber` is changed to Int64.